### PR TITLE
1.2_00

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -1,66 +1,89 @@
--- 名称
-name = "DPSInfo / DPS统计"
--- 版本
-version = "1.2"
--- 描述
-description = "ver " .. version .. [[
+-- Version
+version = "1.2_00"
+-- Name
+name = "DPS/DMG Statistics v" .. version
+-- Description
+description = [[
+ 
+Damage Per Second & Total Damage Statistics
+(only apply to Epic Bosses)
 
-DPS 统计功能
+Translated & Modified for persional use.
 
-p.s. 应急处理一下妥协的报错，给服务器用
-p.s. 本mod功能可以关闭
+Original mod: [ DPSInfo/ DPS统计 ] by [ 胜天一猫 ]
+https://steamcommunity.com/sharedfiles/filedetails/?id=3304784351
 
 ]]
--- 作者
-author = "胜天一猫"
--- klei官方论坛地址，为空则默认是工坊的地址
+-- Author
+author = "胜天一猫 | Modified by VanCa"
+-- Klei official forum address, defaults to the workshop address if empty
 forumthread = ""
--- modicon 下一篇再介绍怎么创建的
+-- Modicon, will introduce how to create it in the next article
 icon_atlas = "modicon.xml"
 icon = "modicon.tex"
--- dst兼容
+-- DST compatible
 dst_compatible = true
--- 是否是客户端mod
+-- Is this a client-side mod
 client_only_mod = false
--- 是否是所有客户端都需要安装
+-- Does every client need to install this mod
 all_clients_require_mod = true
--- 饥荒api版本，固定填10
+-- Hunger Games API version, fixed at 10
 api_version = 10
 priority = 1000
 
--- mod的配置项，后面介绍
+-- Mod configuration options, will be introduced later
 configuration_options = {
     {
         name = "func_open",
-        label = "开关",
-        hover = "功能总开关",
+        label = "Main switch",
+        hover = "Turn this mod on or off",
         options = {
-            {data = "open", description = "打开/open"},
-            {data = "close", description = "关闭/close"},
+            {data = "open", description = "On"},
+            {data = "close", description = "Off"},
         },
         default = "open",
     },
     {
         name = "dps_offset",
-        label = "偏移",
-        hover = "伤害统计偏移位置",
+        label = "Statistics position in combat",
+        hover = "DPS statistics offset position while in combat",
         options = {
-            {data = "middle", description = "中间/middle"},
-            {data = "right", description = "左右/right"},
-            {data = "up", description = "上下/up"},
-            {data = "no", description = "无/no"},
+            {data = "head", description = "Boss's head"},
+            {data = "left_right", description = "Boss's left/right"},
+            {data = "under", description = "Under boss"},
+            {data = "no", description = "None"},
         },
-        default = "right",
+        default = "no",
     },
     {
         name = "dps_end",
-        label = "死后宣告",
-        hover = "是否在击杀后显示总结统计",
+        label = "Statistics after boss dead",
+        hover = "Whether to display summary statistics after boss dead",
         options = {
-            {data = "near", description = "附近"},
-            {data = "all", description = "全局"},
-            {data = "no", description = "否"},
+            {data = "near", description = "Nearby players"},
+            {data = "all", description = "Global"},
+            {data = "no", description = "No"},
         },
         default = "near",
     },
+    {
+        name = "dps_players_only",
+        label = "Top attackers are",
+        hover = "Whether to display mobs/fire's damage in top attackers list",
+        options = {
+            {data = true, description = "Players only"},
+            {data = false, description = "All factors"}
+        },
+        default = false,
+    },
+    {
+        name = "enable_debug_mode",
+        label = "Debug mode",
+        hover = "Whether to write debug logs",
+        options = {
+            {data = true, description = "On"},
+            {data = false, description = "Off"}
+        },
+        default = false,
+    }
 }

--- a/modmain.lua
+++ b/modmain.lua
@@ -1,40 +1,185 @@
-GLOBAL.setmetatable(env, { __index = function(t, k) return GLOBAL.rawget(GLOBAL, k) end })
+TUNING.DEBUG_MODE = GetModConfigData("enable_debug_mode")
+TUNING.DPS_PLAYERS_ONLY = GetModConfigData("dps_players_only")
 
-if GetModConfigData("func_open") ~= "open" then return end
+function table_print(tt, indent, done)
+    done = done or {}
+    indent = indent or 0
+    local spacer = string.rep("  ", indent)
+
+    if type(tt) == "table" then
+        if done[tt] then
+            return "table (circular reference)"
+        end
+        done[tt] = true
+
+        local sb = {"{\n"}
+        for key, value in pairs(tt) do
+            table.insert(sb, spacer .. "  ")
+            if type(key) == "number" then
+                table.insert(sb, string.format("[%d] = ", key))
+            else
+                table.insert(sb, string.format("%s = ", tostring(key)))
+            end
+
+            -- Expand 1 level deep, show type for deeper tables
+            if type(value) == "table" then
+                if indent < 1 then -- Only expand up to 1 level deep
+                    table.insert(sb, table_print(value, indent + 1, done))
+                else
+                    table.insert(sb, tostring(value) .. " (table)")
+                end
+            else
+                table.insert(sb, tostring(value) .. " (" .. type(value) .. ")")
+            end
+            table.insert(sb, ",\n")
+        end
+        table.insert(sb, spacer .. "}")
+        done[tt] = nil -- Allow reuse of this table in other branches
+        return table.concat(sb)
+    else
+        return tostring(tt) .. " (" .. type(tt) .. ")"
+    end
+end
+
+function to_string(tbl)
+    if tbl == nil then
+        return "nil"
+    end
+    if type(tbl) == "table" then
+        return table_print(tbl, 0, {})
+    elseif "string" == type(tbl) then
+        return tbl
+    end
+    return tostring(tbl) .. " (" .. type(tbl) .. ")"
+end
+
+local DebugPrint = TUNING.DEBUG_MODE and function(...)
+        local msg = "[DPSInfo]"
+        for i = 1, arg.n do
+            msg = msg .. " " .. to_string(arg[i])
+        end
+        if arg.n > 1 then
+            msg = msg .. "\n"
+        end
+        print(msg)
+    end or function()
+    end
+
+GLOBAL.setmetatable(
+    env,
+    {
+        __index = function(t, k)
+            return GLOBAL.rawget(GLOBAL, k)
+        end
+    }
+)
+
+if GetModConfigData("func_open") ~= "open" then
+    return
+end
+
+local TOP_DPS_MAX_ENTRY = 4
 
 local dps_say_open = GetModConfigData("dps_offset") ~= "no"
 
 local SAY = function(guid, name, label)
-    -- print("rpc say ", guid, name, label)
+    print("rpc say ", guid, name, label)
     local ent = Ents[guid]
     GLOBAL.Networking_Say(guid, -1, name, ent, label, {0.196, 0.804, 0.196, 1}, false, "none")
 end
 AddClientModRPCHandler("DPSINFO", "SAY", SAY)
 
+local function GenerateDamageReport(inst)
+    inst.sortedPlayerDamage = {}
+    local current_time = GetTime()
+
+    -- Sort players by damage
+    for playerName, damage in pairs(inst.playerDamage) do
+        table.insert(
+            inst.sortedPlayerDamage,
+            {
+                name = playerName,
+                damage = damage,
+                dps = damage / math.max(1, current_time - inst.playerStartTime[playerName])
+            }
+        )
+    end
+    table.sort(
+        inst.sortedPlayerDamage,
+        function(a, b)
+            return a.damage > b.damage
+        end
+    )
+
+    -- Generate player damage text
+    local playerDamageText = {}
+    for i = 1, math.min(TOP_DPS_MAX_ENTRY, #inst.sortedPlayerDamage) do
+        table.insert(
+            playerDamageText,
+            string.format(
+                "%d. %-10s:   %6d dmg (%.2f%%)   %6.2f dps",
+                i,
+                inst.sortedPlayerDamage[i].name,
+                inst.sortedPlayerDamage[i].damage,
+                inst.sortedPlayerDamage[i].damage / inst.totalDamage * 100,
+                inst.sortedPlayerDamage[i].dps
+            )
+        )
+    end
+
+    -- Create base label text
+    local labelText = string.format("------ Total: %d dmg ------", inst.totalDamage)
+
+    if #playerDamageText ~= 0 then
+        labelText = string.format("%s\n%s", labelText, table.concat(playerDamageText, "\n"))
+    end
+    if inst.unknownDamage ~= 0 then
+        labelText =
+            string.format(
+            "%s\nOther sources:   %6d dmg (%.2f%%)",
+            labelText,
+            inst.unknownDamage,
+            inst.unknownDamage / inst.totalDamage * 100
+        )
+    end
+
+    return labelText
+end
+
+local function SplitTextIntoChunks(text)
+    local chunks = {}
+    local maxLength = 150
+
+    -- Split into lines and remove the first one
+    local labelLines = text:split("\n")
+    table.remove(labelLines, 1) -- Remove first line
+
+    -- First split by newlines
+    for _, line in ipairs(labelLines) do
+        -- Then split lines that are still too long
+        local start = 1
+        while start <= #line do
+            local chunk = line:sub(start, start + maxLength - 1)
+            table.insert(chunks, chunk)
+            start = start + maxLength
+        end
+    end
+
+    return chunks
+end
+
 local function OnDeathSay(inst, data)
-    -- print(tostring(inst) .. " dead")
+    -- print("OnDeathSay", tostring(inst) .. " dead")
     if inst:HasTag("epic") then
-        -- 更新伤害显示逻辑
-        local sortedPlayerDamage = {}
-        for playerName, damage in pairs(inst.playerDamage) do
-            table.insert(sortedPlayerDamage, {name = playerName, damage = damage})
-        end
-        table.sort(sortedPlayerDamage, function(a, b) return a.damage > b.damage end)
-
-        local playerDamageText = {}
-        for i = 1, math.min(5, #sortedPlayerDamage) do
-            table.insert(playerDamageText, string.format("%d. %s: %d  %.2f%%", i, sortedPlayerDamage[i].name, sortedPlayerDamage[i].damage,
-                sortedPlayerDamage[i].damage / inst.totalDamage * 100))
-        end
-
-        local labelText = string.format("总伤害: %d\n%s\n其他总伤害: %d",
-                                        inst.totalDamage, table.concat(playerDamageText, "\n"), inst.unknownDamage)
-
+        local bossName = "---------------------\n【 " .. inst:GetDisplayName() .. " 】"
         if data.afflicter and data.afflicter.HasTag then
-            labelText = "击杀者:" .. data.afflicter:GetDisplayName() .. "\n" .. labelText
+            bossName = bossName .. " has been killed by 【 " .. data.afflicter:GetDisplayName() .. " 】"
         end
+        bossName = bossName .. "\n---------------------"
 
-        labelText = "---------------------\n" .. labelText .. "\n---------------------"
+        -- Update damage display logic
+        local labelText = GenerateDamageReport(inst)
+        local chunks = SplitTextIntoChunks(labelText)
 
         -- print(labelText)
         -- GLOBAL.Networking_Say(inst.GUID, -1, inst:GetDisplayName(), inst, labelText, {0.196, 0.804, 0.196, 1}, GetModConfigData("dps_end") == "near", "none")
@@ -45,9 +190,38 @@ local function OnDeathSay(inst, data)
         for index, player in ipairs(AllPlayers) do
             if player and player:IsValid() and player.userid then
                 -- print("check", tostring(player))
-                if not near or player:GetDistanceSqToPoint(x, y, z) < 3600 then
+                local playerName = player:GetDisplayName()
+                if not near or player:GetDistanceSqToPoint(x, y, z) < 3600 or inst.playerDamage[playerName] ~= nil then
                     -- print("send", tostring(player), player:GetDistanceSqToPoint(x, y, z))
-                    SendModRPCToClient(rpc, player.userid, inst.GUID, inst:GetDisplayName(), labelText)
+
+                    SendModRPCToClient(rpc, player.userid, inst.GUID, bossName, "")
+                    for _, chunk in ipairs(chunks) do
+                        SendModRPCToClient(rpc, player.userid, inst.GUID, " ", chunk)
+                    end
+                    -- Add dps info for players who wasn't in the top
+                    if inst.playerDamage[playerName] then
+                        for i = 1, #inst.sortedPlayerDamage do
+                            if inst.sortedPlayerDamage[i].name == playerName then
+                                if i > TOP_DPS_MAX_ENTRY then
+                                    SendModRPCToClient(
+                                        rpc,
+                                        player.userid,
+                                        inst.GUID,
+                                        " ",
+                                        string.format(
+                                            "(top %d) %s:   %6d dmg (%.2f%%)   %6.2f dps",
+                                            i,
+                                            playerName,
+                                            inst.sortedPlayerDamage[i].damage,
+                                            inst.sortedPlayerDamage[i].damage / inst.totalDamage * 100,
+                                            inst.sortedPlayerDamage[i].dps
+                                        )
+                                    )
+                                end
+                                break
+                            end
+                        end
+                    end
                 end
             end
         end
@@ -57,36 +231,27 @@ end
 local function OnAttacked(inst, data)
     if inst:HasTag("epic") then
         -- print("OnAttacked")
-        if not data.damage or data.damage == 0 then return end
+        if not data.damage or data.damage == 0 then
+            return
+        end
+
         local damageAmount = data.damage
 
-        if data.attacker and data.attacker.HasTag and data.attacker:HasTag("player") then
+        if TUNING.DPS_PLAYERS_ONLY and data.attacker:HasTag("player") or not TUNING.DPS_PLAYERS_ONLY then
             local playerName = data.attacker:GetDisplayName()
             inst.playerDamage[playerName] = (inst.playerDamage[playerName] or 0) + damageAmount
+            inst.playerStartTime[playerName] = inst.playerStartTime[playerName] or GetTime()
         else
             inst.unknownDamage = inst.unknownDamage + damageAmount
         end
-        -- 累加到总伤害
+        -- Add to total damage
         inst.totalDamage = inst.totalDamage + damageAmount
 
-        -- 更新伤害显示逻辑
-        local sortedPlayerDamage = {}
-        for playerName, damage in pairs(inst.playerDamage) do
-            table.insert(sortedPlayerDamage, {name = playerName, damage = damage})
-        end
-        table.sort(sortedPlayerDamage, function(a, b) return a.damage > b.damage end)
-
-        local playerDamageText = {}
-        for i = 1, math.min(5, #sortedPlayerDamage) do
-            table.insert(playerDamageText, string.format("%d. %s: %d  %.2f%%", i, sortedPlayerDamage[i].name, sortedPlayerDamage[i].damage,
-                sortedPlayerDamage[i].damage / inst.totalDamage * 100))
-        end
-
-        local labelText = string.format("总伤害: %d\n%s\n其他总伤害: %d",
-                                        inst.totalDamage, table.concat(playerDamageText, "\n"), inst.unknownDamage)
+        -- Update damage display logic
+        local labelText = GenerateDamageReport(inst)
 
         if dps_say_open and inst.components.talker then
-            inst.components.talker:Say(labelText,60)
+            inst.components.talker:Say(labelText, 60)
         end
 
         if inst.deadMsg then
@@ -96,36 +261,43 @@ local function OnAttacked(inst, data)
     end
 end
 
+function CapitalizeFirstChar(str)
+    if str == "" then
+        return str
+    end -- Handle empty strings
+    return str:sub(1, 1):upper() .. str:sub(2)
+end
+
 local function OnHealthDelta(inst, data)
-    if inst:HasTag("epic") and data.afflicter == "fire" then
-        -- print("OnHealthDelta")
-        if not data.amount or data.amount == 0 then return end
-        local damageAmount = math.abs(data.amount)
-        inst.unknownDamage = inst.unknownDamage + damageAmount
-        -- 累加到总伤害
+    DebugPrint("data:", data)
+    if inst:HasTag("epic") and data.cause == "fire" then
+        if not data.amount or data.amount == 0 then
+            return
+        end
+        -- local damageAmount = math.abs(data.amount)
+        -- If the fire heal the boss (?), then decrease its damage
+        local damageAmount = data.amount
+
+        if TUNING.DPS_PLAYERS_ONLY then
+            inst.unknownDamage = inst.unknownDamage - damageAmount
+        else
+            local sourceName = CapitalizeFirstChar(data.cause)
+            inst.playerDamage[sourceName] = (inst.playerDamage[sourceName] or 0) - damageAmount
+            inst.playerStartTime[sourceName] = inst.playerStartTime[sourceName] or GetTime()
+        end
+
+        -- Add to total damage
         inst.totalDamage = inst.totalDamage + damageAmount
 
-        -- 更新伤害显示逻辑
-        local sortedPlayerDamage = {}
-        for playerName, damage in pairs(inst.playerDamage) do
-            table.insert(sortedPlayerDamage, {name = playerName, damage = damage})
-        end
-        table.sort(sortedPlayerDamage, function(a, b) return a.damage > b.damage end)
-
-        local playerDamageText = {}
-        for i = 1, math.min(5, #sortedPlayerDamage) do
-            table.insert(playerDamageText, string.format("%d. %s: %d  %.2f%%", i, sortedPlayerDamage[i].name, sortedPlayerDamage[i].damage,
-                sortedPlayerDamage[i].damage / inst.totalDamage * 100))
-        end
-
-        local labelText = string.format("总伤害: %d\n%s\n其他总伤害: %d",
-                                        inst.totalDamage, table.concat(playerDamageText, "\n"), inst.unknownDamage)
+        -- Update damage display logic
+        local labelText = GenerateDamageReport(inst)
 
         if inst.components.talker then
-            inst.components.talker:Say(labelText,60)
+            inst.components.talker:Say(labelText, 60)
         end
         if inst.deadMsg then
             OnDeathSay(inst, inst.deadMsg)
+            inst.deadMsg = nil
         end
     end
 end
@@ -138,32 +310,37 @@ local function OnDeath(inst, data)
 end
 
 local tbList = {
-    middle = Vector3(0, -700, 0),
-    right = Vector3(650, -700, 0),
-    up = Vector3(0, 700, 0),
+    head = Vector3(0, -1000, 0),
+    left_right = Vector3(900, -700, 0),
+    under = Vector3(0, 700, 0)
 }
 
-AddPrefabPostInitAny(function(inst)
-    if inst:HasTag("epic") then
-        if dps_say_open and not inst.components.talker then
-            inst:AddComponent("talker")
-            inst.components.talker.offset = tbList[GetModConfigData("dps_offset")]
-            inst.components.talker.fontsize = 35
-        end
+AddPrefabPostInitAny(
+    function(inst)
+        if inst:HasTag("epic") then
+            if dps_say_open and not inst.components.talker then
+                inst:AddComponent("talker")
+                inst.components.talker.offset = tbList[GetModConfigData("dps_offset")]
+                inst.components.talker.fontsize = 35
+            end
 
-        if not TheWorld.ismastersim then return end
+            if not TheWorld.ismastersim then
+                return
+            end
 
-        -- print("AddPrefabPostInitAny")
+            -- print("AddPrefabPostInitAny")
 
-        inst.totalDamage = 0
-        inst.playerDamage = inst.playerDamage or {}
-        inst.unknownDamage = 0
+            inst.totalDamage = 0
+            inst.playerDamage = inst.playerDamage or {}
+            inst.playerStartTime = inst.playerStartTime or {}
+            inst.unknownDamage = 0
 
-        inst:ListenForEvent("attacked", OnAttacked)
-        inst:ListenForEvent("healthdelta", OnHealthDelta)
-        if GetModConfigData("dps_end") ~= "no" then
-            -- print("listen death")
-            inst:ListenForEvent("death", OnDeath)
+            inst:ListenForEvent("attacked", OnAttacked)
+            inst:ListenForEvent("healthdelta", OnHealthDelta)
+            if GetModConfigData("dps_end") ~= "no" then
+                -- print("listen death")
+                inst:ListenForEvent("death", OnDeath)
+            end
         end
     end
-end)
+)


### PR DESCRIPTION
Translated to English.

Add DPS in the statistics.

Fix fire damage was not recorded.

Allow show mobs dmg / fire dmg / item dmg in the top list.

Fix an issue where Boss death statistics doesn't show when it's longer than 150 characters. Now also show your DMG statistics even if you weren't on the top.

Players who attended the fight but were far away at the moment the boss died can still receive the statistics.

Improve statistics display.